### PR TITLE
AccountAuthenticator: Pass account name to AuthenticatorActivity

### DIFF
--- a/src/com/udinic/accounts_authenticator_example/authentication/UdinicAuthenticator.java
+++ b/src/com/udinic/accounts_authenticator_example/authentication/UdinicAuthenticator.java
@@ -93,6 +93,7 @@ public class UdinicAuthenticator extends AbstractAccountAuthenticator {
         intent.putExtra(AccountManager.KEY_ACCOUNT_AUTHENTICATOR_RESPONSE, response);
         intent.putExtra(AuthenticatorActivity.ARG_ACCOUNT_TYPE, account.type);
         intent.putExtra(AuthenticatorActivity.ARG_AUTH_TYPE, authTokenType);
+        intent.putExtra(AuthenticatorActivity.ARG_ACCOUNT_NAME, account.name);
         final Bundle bundle = new Bundle();
         bundle.putParcelable(AccountManager.KEY_INTENT, intent);
         return bundle;


### PR DESCRIPTION
Given that `ARG_ACCOUNT_NAME` was not used anywhere else it seems that this got forgotten in the original implementation.
